### PR TITLE
Fix warmth scaling

### DIFF
--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -33,9 +33,10 @@ const Gallery: React.FC = () => {
       return;
     }
   
-    setProducts(prev => prev.map((p, i) =>
-      i === index ? { ...p, warmth: Number(result) || p.warmth, answered: correct } : p
-    ));
+    const warmth = Math.max(0, Math.min(100, Math.round(Number(result) * 10)));
+    setProducts(prev =>
+      prev.map((p, i) => (i === index ? { ...p, warmth, answered: correct } : p))
+    );
   };
 
   return (


### PR DESCRIPTION
## Summary
- scale warmth result from OpenAI to percent so the progress bar fills correctly

## Testing
- `npm run build` *(fails: Cannot find module '@eslint/js')*