### PR TITLE
Improve landing section visibility

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -30,13 +30,34 @@ body {
 }
 
 .scroll-section {
+  position: relative;
   height: 150vh;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 8rem 2rem;
   transition: var(--transition);
-  background: linear-gradient(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.9));
+  background-color: var(--background-color);
+}
+
+.scroll-arrow {
+  position: fixed;
+  bottom: 10vh;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 2rem;
+  color: #1a1a1a;
+  animation: bounce 1.5s infinite;
+  pointer-events: none;
+}
+
+@keyframes bounce {
+  0%, 100% {
+    transform: translateX(-50%) translateY(0);
+  }
+  50% {
+    transform: translateX(-50%) translateY(-10px);
+  }
 }
 
 /* Gallery styles */
@@ -189,7 +210,6 @@ body {
   opacity: 1;
   transform: translateY(0);
   transition: var(--transition);
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .scroll-section.active .section-title {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,8 @@ function App() {
     };
 
     window.addEventListener('scroll', handleScroll);
+    // Trigger once so the first section is visible on load
+    handleScroll();
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
@@ -46,6 +48,7 @@ function App() {
         <ScrollSection
           key={index}
           title={section.title}
+          showArrow={index === 0 && currentSection === 0}
         />
       ))}
       <ScrollSection title="" className="gallery-section">

--- a/src/components/ScrollSection.tsx
+++ b/src/components/ScrollSection.tsx
@@ -5,12 +5,14 @@ interface ScrollSectionProps {
   className?: string;
   isCorrect?: boolean;
   children?: React.ReactNode;
+  showArrow?: boolean;
 }
 
 const ScrollSection: React.FC<ScrollSectionProps> = ({
   title,
   className,
   children,
+  showArrow = false,
 }) => {
   return (
     <div className={`scroll-section ${className || ''}`}>
@@ -18,6 +20,7 @@ const ScrollSection: React.FC<ScrollSectionProps> = ({
         <h2 className="section-title">{title}</h2>
         {children}
       </div>
+      {showArrow && <div className="scroll-arrow">&#x2193;</div>}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- make first section visible on load and show arrow cue
- remove card-like styling from scroll sections
- fix arrow to appear higher and only while first section is active

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*